### PR TITLE
WIP: Update Randen rust for crates.io packaging.

### DIFF
--- a/contrib/rust/Cargo.toml
+++ b/contrib/rust/Cargo.toml
@@ -8,5 +8,5 @@ repository = "https://github.com/google/randen"
 keywords = [ "Crypto", "rng", "random" ]
 
 [dependencies.rand]
-version = "0.4"
+version = "0.5"
 features = ["i128_support"]

--- a/contrib/rust/Cargo.toml
+++ b/contrib/rust/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "randen"
 version = "0.0.0"
-authors = ["Ruud van Asseldonk <ruud@veniogames.com>"]
+authors = ["Ruud van Asseldonk <ruud@veniogames.com>", "Jan Wassenberg <janwas@google.com>", "Brendan Hickey <bhickey@google.com>"]
+license = "Apache-2.0"
+description = "Randen is a fast, backtracking resistant CSPRNG."
+repository = "https://github.com/google/randen"
+keywords = [ "Crypto", "rng", "random" ]
 
 [dependencies.rand]
 version = "0.4"

--- a/contrib/rust/src/lib.rs
+++ b/contrib/rust/src/lib.rs
@@ -5,7 +5,7 @@ extern crate rand;
 use std::mem;
 use std::ops::BitXorAssign;
 
-use rand::{Error, RngCore, SeedableRng};
+use rand::{Error, FromEntropy, RngCore, SeedableRng};
 use std::arch::x86_64::{__m128i, _mm_aesenc_si128};
 
 /// Size of the entire sponge / state for the Randen PRNG.


### PR DESCRIPTION
* Migrates Randen from rand 4.0 to rand 5.0.
* Specifies licensing (Apache 2.0).
* Adds a description and keywords.
* Adds Jan and Brendan as maintainers of the Rust port.